### PR TITLE
simple-node-js-react-npm-app to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -21,4 +21,4 @@ dependencies:
   version: 0.0.1
 - name: simple-node-js-react-npm-app
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.1
+  version: 0.0.2


### PR DESCRIPTION
Promote simple-node-js-react-npm-app to version 0.0.2